### PR TITLE
Do not trigger reset on filtered collection when superset sorts

### DIFF
--- a/backbone-filtered-collection.js
+++ b/backbone-filtered-collection.js
@@ -87,6 +87,10 @@
                 this._collection.reset(filtered);
                 this.length = this._collection.length;
             }
+            function execSort() {
+                this._collection.comparator = this._superset.comparator;
+                this._collection.sort();
+            }
             function onAddChange(model) {
                 this._filterResultCache[model.cid] = {};
                 if (execFilterOnModel.call(this, model)) {
@@ -133,7 +137,8 @@
                 this._collection = new Backbone.Collection(superset.toArray());
                 proxyCollection(this._collection, this);
                 this.resetFilters();
-                this.listenTo(this._superset, 'reset sort', execFilter);
+                this.listenTo(this._superset, 'reset', execFilter);
+                this.listenTo(this._superset, 'sort', execSort);
                 this.listenTo(this._superset, 'add change', onAddChange);
                 this.listenTo(this._superset, 'remove', onModelRemove);
                 this.listenTo(this._superset, 'all', onAll);

--- a/index.js
+++ b/index.js
@@ -69,6 +69,11 @@ function execFilter() {
   this.length = this._collection.length;
 }
 
+function execSort() {
+  this._collection.comparator = this._superset.comparator;
+  this._collection.sort()
+}
+
 function onAddChange(model) {
   // reset the cached results
   this._filterResultCache[model.cid] = {};
@@ -141,7 +146,8 @@ function Filtered(superset) {
   // Set up the filter data structures
   this.resetFilters();
 
-  this.listenTo(this._superset, 'reset sort', execFilter);
+  this.listenTo(this._superset, 'reset', execFilter);
+  this.listenTo(this._superset, 'sort', execSort);
   this.listenTo(this._superset, 'add change', onAddChange);
   this.listenTo(this._superset, 'remove', onModelRemove);
   this.listenTo(this._superset, 'all', onAll);

--- a/test/test.js
+++ b/test/test.js
@@ -1222,6 +1222,19 @@ describe('filtered collection', function() {
       assert(_.isEqual(filtered.pluck('n'), _.range(2, 101, 2)));
     });
 
+    it('does not reset the filtered collection', function() {
+      var called = false;
+
+      filtered.on('reset', function() {
+        called = true;
+      });
+
+      superset.comparator = 'n';
+      superset.sort();
+
+      assert(!called);
+    });
+
   });
 
 });


### PR DESCRIPTION
Fixes #5

I'm not sure I got this 100% correct, so I tried to be minimal. Let me know if I'm missing anything.
